### PR TITLE
fix(YUtils):修复了ProgressDialog会造成内存泄漏的问题

### DIFF
--- a/yutils/src/main/java/com/yechaoa/yutils/YUtils.java
+++ b/yutils/src/main/java/com/yechaoa/yutils/YUtils.java
@@ -87,6 +87,7 @@ public class YUtils {
     public static void hideLoading() {
         if (progressDialog != null && progressDialog.isShowing()) {
             progressDialog.dismiss();
+            progressDialog = null;
         }
     }
 


### PR DESCRIPTION
在progressDialog.dismiss() 后面加了一行progressDialog = null; ，让progressDialog关闭的时候置null，以便可以GC，避免造成progressDialog引用Activity.mContext，造成Activity不能被回收，导致内存泄漏